### PR TITLE
Fix Testing different versions of liquibase

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,5 +42,6 @@ jobs:
         run: |
           python3 -m coverage run --source=./tests/ -m unittest discover -s tests/
           python3 setup.py -q install --user
+          bash tests/test_pyliquibase_version.sh
           cd tests
           pyliquibase --defaultsFile=resources/liquibase.properties updateSQL

--- a/pyliquibase/__init__.py
+++ b/pyliquibase/__init__.py
@@ -105,7 +105,7 @@ class Pyliquibase():
         if not jnius_config.vm_running:
             jnius_config.add_classpath(*LIQUIBASE_CLASSPATH)
         else:
-            log.warning("VM is already running, can't set classpath/options")
+            log.warning("VM is already running, can't set classpath/options! classpath: %s" % jnius_config.get_classpath())
 
         log.debug("classpath: %s" % jnius_config.get_classpath())
 

--- a/tests/test_pyliquibase.py
+++ b/tests/test_pyliquibase.py
@@ -7,11 +7,13 @@ from pyliquibase import Pyliquibase
 
 
 class TestPyliquibase(TestCase):
+
     def setUp(self):
         self.dir_test = pathlib.Path(__file__).parent
         self.testdb = self.dir_test.as_posix() + 'testdb'
         self.testlogfile = self.dir_test.joinpath('liquibase.log')
         os.chdir(self.dir_test.as_posix())
+        self.TEST_LIQUIBASE_VERSION = os.getenv("TEST_LIQUIBASE_VERSION", pyliquibase.DEFAULT_LIQUIBASE_VERSION)
 
     def tearDown(self):
         if os.path.exists(self.testdb):
@@ -27,21 +29,20 @@ class TestPyliquibase(TestCase):
             self.testlogfile.unlink()
 
     def test_update(self):
-        versions = ["4.9.0", "4.10.0", "4.11.0", pyliquibase.DEFAULT_LIQUIBASE_VERSION]
-        for version in versions:
-            self.tearDown()
-            lb = Pyliquibase(version=version,
-                             defaultsFile=os.path.dirname(
-                                 os.path.realpath(__file__)) + "/resources/liquibase.properties")
+        print("Testing LIQUIBASE_VERSION %s" % self.TEST_LIQUIBASE_VERSION)
+        self.tearDown()
+        lb = Pyliquibase(version=self.TEST_LIQUIBASE_VERSION,
+                         defaultsFile=os.path.dirname(
+                             os.path.realpath(__file__)) + "/resources/liquibase.properties")
 
-            lb.addarg("--log-level", "info")
-            lb.addarg("--log-file", self.testlogfile.as_posix())
+        lb.addarg("--log-level", "info")
+        lb.addarg("--log-file", self.testlogfile.as_posix())
 
-            lb.status()
-            lb.execute("validate")
-            lb.execute("updateSQL")
-            lb.execute("update")
-            self.assertTrue(True)
+        lb.status()
+        lb.execute("validate")
+        lb.execute("updateSQL")
+        lb.execute("update")
+        self.assertTrue(True)
 
     def test_exception(self):
         lb = Pyliquibase(

--- a/tests/test_pyliquibase_version.sh
+++ b/tests/test_pyliquibase_version.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+declare -a lbVersionList=("4.9.0" "4.10.0" "4.11.0")
+for version in "${lbVersionList[@]}"; do
+  export TEST_LIQUIBASE_VERSION=$version
+  echo "Testing TEST_LIQUIBASE_VERSION ${TEST_LIQUIBASE_VERSION}"
+  python -m unittest -v tests.test_pyliquibase.TestPyliquibase.test_update
+done


### PR DESCRIPTION
in order to test different versions of liquibase we need to initialize JVM (run the test) as seperate processes