### PR TITLE
Fix a bug when downloading new Liquibase version on Windows temp dir

### DIFF
--- a/pyliquibase/__init__.py
+++ b/pyliquibase/__init__.py
@@ -238,13 +238,14 @@ class Pyliquibase():
         :param destination: 
         :return: 
         """
-        with tempfile.NamedTemporaryFile(suffix="_liquibase.zip") as tmpfile:
+        with tempfile.NamedTemporaryFile(suffix="_liquibase.zip", delete=False) as tmpfile:
             log.info("Downloading %s to %s" % (url, destination))
             self._download_file(url, tmpfile.name)
 
             log.info("Extracting to %s" % (destination))
             with zipfile.ZipFile(tmpfile, 'r') as zip_ref:
                 zip_ref.extractall(destination)
+        os.unlink(tmpfile.name)
 
     def _download_file(self, url: str, destination: str) -> None:
         """downloads file from given url and saves to destination path


### PR DESCRIPTION
I was getting the following error message after upgrading my pyliquibase package from 2.0.11 to 2.0.12:

2023-06-30 17:34:32,309 - WARNING - Downloading Liquibase version: 4.21.1 ...
2023-06-30 17:34:32,310 - INFO - Downloading https://github.com/liquibase/liquibase/releases/download/v4.21.1/liquibase-4.21.1.zip to C:\Users\alexa\Envs\falcon-db\lib\site-packages\pyliquibase\liquibase-4.21.1    
url = https://github.com/liquibase/liquibase/releases/download/v4.21.1/liquibase-4.21.1.zip
destination = C:\Users\alexa\AppData\Local\Temp\tmpw76m_sqg_liquibase.zip
2023-06-30 17:34:32,929 - ERROR - Failed to download https://github.com/liquibase/liquibase/releases/download/v4.21.1/liquibase-4.21.1.zip
Unable to update database falcon-auth through liquibase
Traceback (most recent call last):
  File ".\initdb.py", line 111, in liquibase_update
    liquibase = Pyliquibase(
  File "C:\Users\alexa\Envs\falcon-db\lib\site-packages\pyliquibase\__init__.py", line 87, in __init__
    self._download_liquibase()
  File "C:\Users\alexa\Envs\falcon-db\lib\site-packages\pyliquibase\__init__.py", line 196, in _download_liquibase
    self._download_zipfile(url=LIQUIBASE_ZIP_URL.format(self.version, self.version),
  File "C:\Users\alexa\Envs\falcon-db\lib\site-packages\pyliquibase\__init__.py", line 240, in _download_zipfile
    self._download_file(url, tmpfile.name)
  File "C:\Users\alexa\Envs\falcon-db\lib\site-packages\pyliquibase\__init__.py", line 257, in _download_file
    raise e
  File "C:\Users\alexa\Envs\falcon-db\lib\site-packages\pyliquibase\__init__.py", line 254, in _download_file
    request.urlretrieve(url, destination)
  File "c:\python38\lib\urllib\request.py", line 257, in urlretrieve
    tfp = open(filename, 'wb')
PermissionError: [Errno 13] Permission denied: 'C:\\Users\\alexa\\AppData\\Local\\Temp\\tmpw76m_sqg_liquibase.zip'

After some researches, I found that the issue was due to a permission problem on Windows when constructing a `NamedTemporaryFile` object with `delete` argument to `True`. I fixed the issue by forcing `delete` to `False` when constructing the `NamedTemporaryFile` object and then delete it with `os.unlink()` method.